### PR TITLE
[Mesos] Limit the default number of libprocess worker threads for executors to 8.

### DIFF
--- a/gen/dcos-config.yaml
+++ b/gen/dcos-config.yaml
@@ -279,7 +279,8 @@ package:
         "PATH": "/usr/bin:/bin",
         "SHELL": "/usr/bin/bash",
         "LD_LIBRARY_PATH": "/opt/mesosphere/lib",
-        "SASL_PATH": "/opt/mesosphere/lib/sasl2"
+        "SASL_PATH": "/opt/mesosphere/lib/sasl2",
+        "LIBPROCESS_NUM_WORKER_THREADS": "8"
       }
   - path: /etc/dns_search_config
     content: |


### PR DESCRIPTION
This limitation improves performance and memory consumption on hosts with large number of cores.
Schedulers running custom executors can still override this value by providing it in their executor definition.
